### PR TITLE
[DWarning] The final build of Warning Module

### DIFF
--- a/Sources/DefinedElements/Frameworks/Warning/DWarning.Global.swift
+++ b/Sources/DefinedElements/Frameworks/Warning/DWarning.Global.swift
@@ -1,19 +1,28 @@
-//
-//  File.swift
-//  
-//
-//  Created by Lingxi Li on 6/14/21.
-//
-
 import Foundation
 
+/// [DE] A general warning module for some less potential warning units.
 ///
+///   - Important: If a unit may generate some warnings inside itself, whatever the cause is,
+///   you should use `DefinedPotentialWarning` protocol instead of this.
+///
+///   It can be much easier and safer (we might make some smart warning handlers in the future).
 public struct DefinedWarning : DefinedPotentialWarning {
-    var name: String
+    public var name: String
     
-    public init(from: String? = nil, _ message: String) {
+    /// [DE] Create a general warning sender on console.
+    ///
+    /// - Parameters:
+    ///   - from: The name of the module that generates this warning. (optional)
+    private init(from: String? = nil) {
         self.name = from ?? "<Global>"
-        
-        self.warning(message)
+    }
+    
+    /// [DE] Send a general warning on console.
+    ///
+    /// - Parameters:
+    ///   - from: The name of the module that generates this warning. (optional)
+    ///   - message: The message of the warning. (required)
+    public static func send(from: String? = nil, _ message: String) {
+        DefinedWarning(from: from).warning(message)
     }
 }

--- a/Sources/DefinedElements/Frameworks/Warning/DWarning.Protocol.swift
+++ b/Sources/DefinedElements/Frameworks/Warning/DWarning.Protocol.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 /// [DE] A protocol for all units or modules that may generate a warning for developers when something goes wrong.
 public protocol DefinedPotentialWarning {
@@ -10,12 +9,17 @@ public protocol DefinedPotentialWarning {
     /// - Important: It is required because the developer get a warning needs to know which unit goes wrong.
     var name: String { get }
     
+    /// [DE] Generate a warning.
     ///
+    /// - Parameter message: The message of the warning. (required)
     func warning(_ message: String) -> Void
 }
 
 public extension DefinedPotentialWarning {
-    func warning(_ message: String? = nil) {
-        print("-- [DefinedWarning] \(name)\n-- WARNING: \(message == nil ? "An intentional warning but no description provided." : message)")
+    /// [DE] Generate a warning by `DefinedPotentialWarning`.
+    ///
+    /// - Parameter message: The message of the warning. (required)
+    func warning(_ message: String) {
+        print(">> [DefinedWarning] \(name)\n>> - WARNING: \(message)")
     }
 }


### PR DESCRIPTION
## Why do we need this?

The purpose of building `DefinedWarning` module is that when we have something being improperly used, we should NOT crash the program immediately (especially as a UI library/framework). Instead, we need a way to tell the developer that something which should not happen did happen.

Currently, I did not find any API that I can generate a native warning during runtime.
So our workaround is printing them out with a specific format and doing constrains in our API.

And since we make this as a dedicate module, we can easily improve it in the future when we have a better solution.

## Works

- [X] Standardize the API
- [X] Documents